### PR TITLE
Fix LPC15XX extended CAN ID conversion

### DIFF
--- a/targets/TARGET_NXP/TARGET_LPC15XX/can_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC15XX/can_api.c
@@ -566,8 +566,8 @@ int can_read(can_t *obj, CAN_Message *msg, int handle) {
 
         if (LPC_C_CAN0->CANIF2_ARB2 & CANIFn_ARB2_XTD) {
             msg->format = CANExtended;
-            msg->id = (LPC_C_CAN0->CANIF2_ARB1 & 0x1FFF) << 16;
-            msg->id |= (LPC_C_CAN0->CANIF2_ARB2 & 0x1FFF);
+            msg->id = (LPC_C_CAN0->CANIF2_ARB2 & 0x1FFF) << 16;
+            msg->id |= (LPC_C_CAN0->CANIF2_ARB1 & 0xFFFF);
         } else {
             msg->format = CANStandard;
             msg->id = (LPC_C_CAN0->CANIF2_ARB2 & 0x1FFF) >> 2;


### PR DESCRIPTION
This fixes on the LPC15XX the conversion of the CAN ID when receiving an extended frame.